### PR TITLE
some fixes for Windows

### DIFF
--- a/datafile/openers/windows.lua
+++ b/datafile/openers/windows.lua
@@ -15,7 +15,7 @@ function windows.opener(file, mode, _)
    local dirs = {}
    if context == "config" then
       dirs[#dirs+1] = os.getenv("APPDATA")
-      dirs[#dirs+1] = (os.getenv("PROGRAMDATA") or os.getenv("ALLUSERSPROFILE")) }
+      dirs[#dirs+1] = (os.getenv("PROGRAMDATA") or os.getenv("ALLUSERSPROFILE"))
    end
    dirs[#dirs+1] = os.getenv("USERPROFILE")
    dirs[#dirs+1] = os.getenv("PUBLIC")

--- a/datafile/openers/windows.lua
+++ b/datafile/openers/windows.lua
@@ -11,7 +11,7 @@ local windows = {}
 
 local util = require("datafile.util")
 
-function windows.opener(file, mode, _)
+function windows.opener(file, mode, context)
    local dirs = {}
    if context == "config" then
       dirs[#dirs+1] = os.getenv("APPDATA")


### PR DESCRIPTION
You might want to remove the XDG opener from Windows.

It currently fails silently with a nil-concatenation because `os.getenv("HOME")` returns `nil` on Windows. And I couldn't find a sensible default value for that on Windows.