### PR TITLE
Check for manifest in versioned rocks trees first

### DIFF
--- a/datafile/openers/luarocks.lua
+++ b/datafile/openers/luarocks.lua
@@ -19,10 +19,10 @@ function luarocks.opener(file, mode, context)
       local prefix, luaver, modpath = source:match("@(.*)/share/lua/([^/]*)/(.*)")
       if prefix and luaver and modpath then
          local modname = path.path_to_module(modpath):gsub("\\","."):gsub("/",".")
-         local rocks_dir = prefix.."/lib/luarocks/rocks"
+         local rocks_dir = prefix.."/lib/luarocks/rocks-"..luaver
          local manifest, err = manif_core.load_local_manifest(rocks_dir)
-         if not manifest then
-            rocks_dir = prefix.."/lib/luarocks/rocks-"..luaver
+         if not manifest then -- look for generic rocks_dir
+            rocks_dir = prefix.."/lib/luarocks/rocks"
             manifest, err = manif_core.load_local_manifest(rocks_dir)
          end
          if not manifest then


### PR DESCRIPTION
When a versioned rocks tree and a non-versioned rocks tree coexist, prefer the versioned one.

* On a machine with a single rocks tree, versioned or no, this has no effect.
* On a machine with both, and the unversioned tree points to the right
  lua version, this has no effect.
* But on a machine where the unversioned tree points to another version
  of lua, the right manifest file will be read instead of the wrong one.

This patch resolves a problem I posted to the mailing list where datafile wasn't generating the paths needed to find my luarocks-installed templates: Since luarocks installed them to a directory with my package version in it, datafile would have needed the correct manifest to find it, and since it was actually finding a manifest, just not the right one, it gave no outward error.
