### PR TITLE
fix(*): make datafile load when HOME environment variable is not set

### DIFF
--- a/datafile/openers/unix.lua
+++ b/datafile/openers/unix.lua
@@ -27,11 +27,15 @@ function unix.get_dirs(context)
       end
    end
    if context == "config" then
-      table.insert(dirs, home.."/.config")
-      table.insert(dirs, home.."/.|") -- the pipe marker tells not to add a trailing slash
+      if home then
+         table.insert(dirs, home.."/.config")
+         table.insert(dirs, home.."/.|") -- the pipe marker tells not to add a trailing slash
+      end
       table.insert(dirs, "/etc/")
    elseif context == "cache" then
-      table.insert(dirs, home.."/.cache")
+      if home then
+         table.insert(dirs, home.."/.cache")
+      end
       table.insert(dirs, "/var/cache")
       table.insert(dirs, "/var/run")
       table.insert(dirs, "/var/lib")

--- a/datafile/openers/xdg.lua
+++ b/datafile/openers/xdg.lua
@@ -25,7 +25,9 @@ table.insert(XDG_DATA_DIRS, XDG_RUNTIME_DIR)
 local XDG_CONFIG_DIRS = split(os.getenv("XDG_CONFIG_DIRS") or "/etc/xdg")
 table.insert(XDG_CONFIG_DIRS, 1, XDG_CONFIG_HOME)
 
-local XDG_CACHE_DIRS = { XDG_CACHE_HOME, XDG_RUNTIME_DIR }
+local XDG_CACHE_DIRS = {}
+table.insert(XDG_CACHE_DIRS, XDG_CACHE_HOME)
+table.insert(XDG_CACHE_DIRS, XDG_RUNTIME_DIR)
 
 function xdg.get_dirs(context)
    local dirs = XDG_DATA_DIRS

--- a/datafile/openers/xdg.lua
+++ b/datafile/openers/xdg.lua
@@ -13,9 +13,9 @@ local function split(var)
 end
 
 local HOME = os.getenv("HOME")
-local XDG_DATA_HOME   = os.getenv("XDG_DATA_HOME")   or HOME.."/.local/share"
-local XDG_CONFIG_HOME = os.getenv("XDG_CONFIG_HOME") or HOME.."/.config"
-local XDG_CACHE_HOME  = os.getenv("XDG_CACHE_HOME")  or HOME.."/.cache"
+local XDG_DATA_HOME   = os.getenv("XDG_DATA_HOME")   or (HOME and HOME.."/.local/share")
+local XDG_CONFIG_HOME = os.getenv("XDG_CONFIG_HOME") or (HOME and HOME.."/.config")
+local XDG_CACHE_HOME  = os.getenv("XDG_CACHE_HOME")  or (HOME and HOME.."/.cache")
 local XDG_RUNTIME_DIR = os.getenv("XDG_RUNTIME_DIR")
 
 local XDG_DATA_DIRS = split(os.getenv("XDG_DATA_DIRS") or "/usr/local/share:/usr/share")


### PR DESCRIPTION
Without this fix, the xdg and unix openers would silently fail to load, making datafile not work properly.