### PR TITLE
fix: `datafile.path` skips valid file-descriptor found via custom opener

### DIFF
--- a/datafile.lua
+++ b/datafile.lua
@@ -67,7 +67,7 @@ end
 
 function datafile.path(file, mode, context)
    local fd, path = datafile.open(file, mode or "r", context, find_file)
-   if fd == true then
+   if fd then
       return path
    end
    return nil, path


### PR DESCRIPTION
`datafile.path()` currently doesn't work with custom `.opener()` functions that return a file-descriptor instead of `true`.

**Example**:
 ```lua
table.insert(datafile.openers, 1, { opener = function(path, mode, ctx) return customio.open(path, mode) end })
```

This PR relaxes the condition in `datafile.path()` to accept file-descriptors returned by `.opener()` functions.